### PR TITLE
色差によるバフ計算実装等

### DIFF
--- a/Assets/MyAsset/Scripts/DevUtil.meta
+++ b/Assets/MyAsset/Scripts/DevUtil.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b04c7b8b8a245324ab0a34ca10f2cdd0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Scripts/DevUtil/ColorUtilities.cs
+++ b/Assets/MyAsset/Scripts/DevUtil/ColorUtilities.cs
@@ -1,0 +1,106 @@
+using System;
+
+namespace MyAsset.Scripts.DevUtil
+{
+    public class ColorUtil
+    {
+        private double[,] m = new double[3,3]{ { 0.4124f, 0.3576f, 0.1805f },
+            { 0.2126f, 0.7152f, 0.0722f },
+            { 0.0193f, 0.1192f, 0.9505f } };
+        
+        private double GetX(double r, double g, double b){
+            return m[0,0] * r + m[0,1] * g + m[0,2] * b;
+        }
+        private double GetY(double r, double g, double b){
+            return m[1,0] * r + m[1,1] * g + m[1,2] * b;
+        }
+        private double GetZ(double r, double g, double b){
+            return m[2,0] * r + m[2,1] * g + m[2,2] * b;
+        }
+        
+        private double[] RGB2XYZ(double[] c){
+            return new double[]{
+                GetX(c[0], c[1], c[2]),
+                GetY(c[0], c[1], c[2]),
+                GetZ(c[0], c[1], c[2])
+            };
+        }
+        
+        public double[] XYZ2Lab(double[] xyz){
+            double[] dst = new double[3];
+            double[] whitePoint = RGB2XYZ(new double[]{ 255, 255, 255 });
+            double xxn = Func(xyz[0] / whitePoint[0]);
+            double yyn = Func(xyz[1] / whitePoint[1]);
+            double zzn = Func(xyz[2] / whitePoint[2]);
+            dst[0] = 116f * yyn - 16;
+            dst[1] = 500 * (xxn - yyn);
+            dst[2] = 200 * (yyn - zzn);
+
+            return dst;
+        }
+        
+        private double Func(double t){
+            if(t > Math.Pow(6d/29, 3)){
+                return Math.Pow(t, 1d/3);
+            } else {
+                return 1d/3 * 29d/6 * 29d/6 * t + 4d/29;
+            }
+        }
+
+        public double RadianToDegree(double radian)
+        {
+            return radian * (180 / Math.PI);
+        }
+
+        public static double DegreeToRadian(double degree)
+        {
+            return degree * (Math.PI / 180);
+        }
+
+        public double CalcColorDifferent(double[] src, double[] sample)
+        {
+            double[] labSrc = XYZ2Lab(RGB2XYZ(src));
+            double[] labSample = XYZ2Lab(RGB2XYZ(sample));
+            return Cie94(labSrc, labSample);
+        }
+
+        private double Cie94(double[] lab1, double[] lab2)
+        {
+            //https://en.wikipedia.org/wiki/Color_difference#CIE94
+
+            double kL = 1, kC = 1, kH = 1;
+            double K1, K2;
+            if (kL == 1)
+            {
+                K1 = 0.045;
+                K2 = 0.015;
+            }
+            else
+            {
+                K1 = 0.048;
+                K2 = 0.014;
+            }
+
+            var deltaL = lab1[0] - lab2[0];
+            var C1 = Math.Sqrt(Math.Pow(lab1[1], 2) + Math.Pow(lab1[2], 2));
+            var C2 = Math.Sqrt(Math.Pow(lab2[1], 2) + Math.Pow(lab2[2], 2));
+            var deltaCab = C1 - C2;
+            var deltaa = lab1[1] - lab2[1];
+            var deltab = lab1[2] - lab2[2];
+            var deltaHab = Math.Sqrt(
+                Math.Pow(deltaa, 2) +
+                Math.Pow(deltab, 2) -
+                Math.Pow(deltaCab, 2)
+            );
+            var SL = 1;
+            var SC = 1 + (K1 * C1);
+            var SH = 1 + (K2 * C1);
+
+            return Math.Sqrt(
+                Math.Pow((deltaL / (kL * SL)), 2) +
+                Math.Pow((deltaCab / (kC * SC)), 2) +
+                Math.Pow((deltaHab / (kH * SH)), 2)
+            );
+        }
+    }
+}

--- a/Assets/MyAsset/Scripts/DevUtil/ColorUtilities.cs.meta
+++ b/Assets/MyAsset/Scripts/DevUtil/ColorUtilities.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5db81c6b0d11d3942906347e35cde5e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MyAsset/Scripts/Monster.cs
+++ b/Assets/MyAsset/Scripts/Monster.cs
@@ -78,7 +78,7 @@ public class Monster : MonoBehaviour
         double[] color32 = new double[] {StatusColor.r, StatusColor.g, StatusColor.b};
         double buffNum = new ColorUtil().CalcColorDifferent(color32,red);
         float minBuff = buffRange.x,maxBuff = buffRange.y;
-        Buff = (100 - (float)buffNum) / 100f * maxBuff + minBuff;
+        Buff = (100f - (float)buffNum) / 100f * (maxBuff-minBuff) + minBuff;
         //SpacialCommand = commands[rNum[1] % commands.Length];
 
         int seedMaxNum = 15;

--- a/Assets/MyAsset/Scripts/Monster.cs
+++ b/Assets/MyAsset/Scripts/Monster.cs
@@ -1,12 +1,8 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEditor;
 using GD.MinMaxSlider;
-using UnityEngine.Serialization;
-
+using MyAsset.Scripts.DevUtil;
 /// <summary>
 /// モンスターの基礎ステータスを管理するクラス
 /// </summary>
@@ -54,6 +50,7 @@ public class Monster : MonoBehaviour
 
     [Header("特殊コマンドリスト")] [SerializeField] private BaseCommand[] commands;
     private readonly int[] randNums = new int[] {8,2,7,15,10,0,12,1,13,3,5,11,9,6,14,4};
+    [SerializeField] private double MaxDiff;
     
     /// <summary>
     /// 引数として受け取ったカラーコードからステータスを生成するメソッド
@@ -77,8 +74,11 @@ public class Monster : MonoBehaviour
         int[] gNum = HexToIntArray(colorCode.Substring(2, 2));
         int[] bNum = HexToIntArray(colorCode.Substring(4, 2));
         
+        double[] red = new double[] {255, 0, 0};
+        double[] color32 = new double[] {StatusColor.r, StatusColor.g, StatusColor.b};
+        double buffNum = new ColorUtil().CalcColorDifferent(color32,red);
         float minBuff = buffRange.x,maxBuff = buffRange.y;
-        Buff = rNum[0] / 15f * maxBuff + minBuff;
+        Buff = (100 - (float)buffNum) / 100f * maxBuff + minBuff;
         //SpacialCommand = commands[rNum[1] % commands.Length];
 
         int seedMaxNum = 15;
@@ -102,7 +102,7 @@ public class Monster : MonoBehaviour
         int offset = (int) Math.Round((double) value / (double) seedMax * max-min);
         return offset + min;
     }
-    
+      
     /// <summary>
     /// 16進数文字列を1文字ごとにintに変換しint型の配列で返す関数
     /// </summary>
@@ -111,10 +111,11 @@ public class Monster : MonoBehaviour
     private int[] HexToIntArray(string hexStr)
     {
         int[] intArray = new int[hexStr.Length];
-        foreach (var hexItem in hexStr.Select((hexChar, index) => new { hexChar, index }))
+        foreach (var hexItem in hexStr.Select((hexChar, index) => new {hexChar, index}))
         {
             intArray[hexItem.index] = Convert.ToInt32(hexItem.hexChar.ToString(), 16);
         }
+
         return intArray;
     }
 }

--- a/Assets/MyAsset/Scripts/Monster.cs
+++ b/Assets/MyAsset/Scripts/Monster.cs
@@ -51,6 +51,15 @@ public class Monster : MonoBehaviour
     [Header("特殊コマンドリスト")] [SerializeField] private BaseCommand[] commands;
     private readonly int[] randNums = new int[] {8,2,7,15,10,0,12,1,13,3,5,11,9,6,14,4};
     [SerializeField] private double MaxDiff;
+
+    public void BuildStatusManual(float buff,int hp,int atk,int def,int mp)
+    {
+        Buff = buff;
+        BaseHp = hp;
+        BaseAtk = atk;
+        BaseDef = def;
+        BaseMp = mp;
+    } 
     
     /// <summary>
     /// 引数として受け取ったカラーコードからステータスを生成するメソッド


### PR DESCRIPTION
## 概要
* バフをCIE94で計算した値で求めるよう変更
* バフの計算式を修正
* 手動でステータスを設定するメソッドを追加

## デバッグ項目
- [x]  色差計算は見たとこ問題ありません(白黒の差100,明度差は結果に影響しづらい等)
 